### PR TITLE
Fix path where dashboards are installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,11 +68,11 @@ grafana_feature_toggles_enable: ''
 # See `../templates/provisioning/dashboards.yaml.j2`
 grafana_provisioning_dashboard_providers:
   - name: Dashboards
-    folder: ''  # The folder where to place the dashboards
+    folder: ''  # Name of the folder with provisoned dashboards in grafana
     type: file
     allowUiUpdates: true
     options:
-      path: /etc/grafana/dashboards
+      path: '/etc/grafana/dashboards' # The folder where to place the dashboards
 
 # Configure smtp settings for sending email notifications
 #
@@ -92,10 +92,10 @@ grafana_smtp_from_address: ""
 # A list of template files on the Ansible controller server to install into the dashboards directory.
 #
 # Example:
-# grafana_provisioning_dashboard_template_files:
+# grafana_dashboard_template_files:
 #   - name: /path/to/my-dashboard.json
 #     name: my-dashboard.json
-grafana_provisioning_dashboard_template_files: []
+grafana_dashboard_template_files: []
 
 # A list of provisioning datasources.
 # See `../templates/provisioning/datasources.yaml.j2`

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,11 +52,11 @@
 - name: Ensure dashboard templates installed
   ansible.builtin.template:
     src: "{{ item.path }}"
-    dest: "{{ grafana_config_path }}/provisioning/dashboards/{{ item.name }}"
+    dest: "{{ grafana_config_path }}/dashboards/{{ item.name }}"
     mode: "0440"
     owner: "{{ grafana_uid }}"
     group: "{{ grafana_gid }}"
-  with_items: "{{ grafana_provisioning_dashboard_template_files }}"
+  with_items: "{{ grafana_dashboard_template_files }}"
 
 - name: Ensure Grafana image is pulled
   community.docker.docker_image:


### PR DESCRIPTION
Dashboard files should be installed in the directory specified by path in provides config that defined in `grafana_provisioning_dashboard_providers` var.
So change destination directory and give more suitable name for the variable with templates list - `grafana_dashboard_template_files`.
[Grafana providers doc](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards)