### PR TITLE
Introduce grafana_dashboard_files variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,13 +89,21 @@ grafana_smtp_user: ""
 grafana_smtp_password: ""
 grafana_smtp_from_address: ""
 
-# A list of template files on the Ansible controller server to install into the dashboards directory.
+# A list of template files on the Ansible controller server to install into the dashboard provisioning directory.
 #
 # Example:
 # grafana_provisioning_dashboard_template_files:
-#   - name: /path/to/my-dashboard.json
+#   - name: /path/to/my-dashboard-provisioning.json
 #     name: my-dashboard.json
 grafana_provisioning_dashboard_template_files: []
+
+# A list of files on the Ansible controller server to install into the dashboards directory.
+#
+# Example:
+# grafana_dashboard_files:
+#   - name: /path/to/my-dashboard.json
+#     name: my-dashboard.json
+grafana_dashboard_files: []
 
 # A list of provisioning datasources.
 # See `../templates/provisioning/datasources.yaml.j2`

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,7 +49,7 @@
   delay: "{{ devture_playbook_help_geturl_retries_delay }}"
   until: result is not failed
 
-- name: Ensure dashboard templates installed
+- name: Ensure provisioning dashboard templates installed
   ansible.builtin.template:
     src: "{{ item.path }}"
     dest: "{{ grafana_config_path }}/provisioning/dashboards/{{ item.name }}"
@@ -57,6 +57,15 @@
     owner: "{{ grafana_uid }}"
     group: "{{ grafana_gid }}"
   with_items: "{{ grafana_provisioning_dashboard_template_files }}"
+
+- name: Ensure dashboard files installed
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    dest: "{{ grafana_config_path }}/dashboards/{{ item.name }}"
+    mode: "0440"
+    owner: "{{ grafana_uid }}"
+    group: "{{ grafana_gid }}"
+  with_items: "{{ grafana_dashboard_files }}"
 
 - name: Ensure Grafana image is pulled
   community.docker.docker_image:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,8 +59,8 @@
   with_items: "{{ grafana_provisioning_dashboard_template_files }}"
 
 - name: Ensure dashboard files installed
-  ansible.builtin.file:
-    path: "{{ item.path }}"
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
     dest: "{{ grafana_config_path }}/dashboards/{{ item.name }}"
     mode: "0440"
     owner: "{{ grafana_uid }}"


### PR DESCRIPTION
Introduce **grafana_dashboard_files** variable that contains a list of files on the Ansible controller to install into the dashboards directory.
It provides a way to put custom dashboards to the _/etc/grafana/dashboards_ directory inside grafana container.