### PR TITLE
Support alerting and plugin file provisioning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,16 +77,6 @@ grafana_default_home_dashboard_path: ''
 # Leave it empty to not enable any experimental features.
 grafana_feature_toggles_enable: ''
 
-# A list of provisioning dashboard providers.
-# See `../templates/provisioning/dashboards.yaml.j2`
-grafana_provisioning_dashboard_providers:
-  - name: Dashboards
-    folder: ''  # The folder where to place the dashboards
-    type: file
-    allowUiUpdates: true
-    options:
-      path: /etc/grafana/dashboards
-
 # Configure SMTP settings for sending email notifications.
 #
 # Example:
@@ -110,9 +100,43 @@ grafana_smtp_from_address: ""
 #     name: my-dashboard.json
 grafana_provisioning_dashboard_template_files: []
 
+# A list of provisioning dashboard providers.
+# See `../templates/provisioning/dashboards.yaml.j2`
+grafana_provisioning_dashboard_providers:
+  - name: Dashboards
+    folder: ''  # The folder where to place the dashboards
+    type: file
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards
+
 # A list of provisioning datasources.
 # See `../templates/provisioning/datasources.yaml.j2`
 grafana_provisioning_datasources: []
+
+# A list of provisioning alerts.
+# See `../templates/provisioning/alerts.yaml.j2`
+grafana_provisioning_alerts: []
+
+# A list of provisioning contact points.
+# See `../templates/provisioning/contact_points.yaml.j2`
+grafana_provisioning_contact_points: []
+
+# A list of provisioning notification policies.
+# See `../templates/provisioning/notification_policies.yaml.j2`
+grafana_provisioning_notification_policies: []
+
+# A list of provisioning mute timings.
+# See `../templates/provisioning/mute_timings.yaml.j2`
+grafana_provisioning_mute_timings: []
+
+# A list of provisioning notification template groups.
+# See `../templates/provisioning/notification_template_groups.yaml.j2`
+grafana_provisioning_notification_template_groups: []
+
+# A list of provisioning plugins.
+# See `../templates/provisioning/plugins.yaml.j2`
+grafana_provisioning_plugins: []
 
 grafana_container_image: "{{ grafana_container_image_registry_prefix }}grafana/grafana-oss:{{ grafana_version }}"
 grafana_container_image_registry_prefix: "{{ grafana_container_image_registry_prefix_upstream }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,6 +110,10 @@ grafana_provisioning_dashboard_providers:
     options:
       path: /etc/grafana/dashboards
 
+# Configures Grafana to automatically delete previously provisioned data sources
+# when they’re removed from `grafana_provisioning_datasources`
+grafana_provisioning_prune_datasources: true
+
 # A list of provisioning datasources to apply and delete.
 # See `../templates/provisioning/datasources.yaml.j2`
 grafana_provisioning_datasources: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,7 +102,7 @@ grafana_provisioning_dashboard_template_files: []
 
 # A list of provisioning dashboard providers.
 # See `../templates/provisioning/dashboards.yaml.j2`
-grafana_provisioning_dashboard_providers:
+grafana_provisioning_dashboards_providers:
   - name: Dashboards
     folder: ''  # The folder where to place the dashboards
     type: file
@@ -111,42 +111,42 @@ grafana_provisioning_dashboard_providers:
       path: /etc/grafana/dashboards
 
 # Configures Grafana to automatically delete previously provisioned data sources
-# when they’re removed from `grafana_provisioning_datasources`
-grafana_provisioning_prune_datasources: true
+# when they’re removed from `grafana_provisioning_datasources_datasources`
+grafana_provisioning_datasources_prune: true
 
 # A list of provisioning datasources to apply and delete.
 # See `../templates/provisioning/datasources.yaml.j2`
-grafana_provisioning_datasources: []
-grafana_provisioning_delete_datasources: []
+grafana_provisioning_datasources_datasources: []
+grafana_provisioning_datasources_deleteDatasources: []  # noqa var-naming
 
 # A list of provisioning alerts to apply and delete.
 # See `../templates/provisioning/alerts.yaml.j2`
-grafana_provisioning_alerts: []
-grafana_provisioning_delete_alerts: []
+grafana_provisioning_alerts_groups: []
+grafana_provisioning_alerts_deleteRules: []  # noqa var-naming
 
 # A list of provisioning contact points to apply and delete.
 # See `../templates/provisioning/contact_points.yaml.j2`
-grafana_provisioning_contact_points: []
-grafana_provisioning_delete_contact_points: []
+grafana_provisioning_contact_points_contactPoints: []  # noqa var-naming
+grafana_provisioning_contact_points_deleteContactPoints: []  # noqa var-naming
 
 # A list of provisioning notification policies to apply and reset.
 # See `../templates/provisioning/notification_policies.yaml.j2`
-grafana_provisioning_notification_policies: []
-grafana_provisioning_reset_notification_policies: []
+grafana_provisioning_notification_policies_policies: []
+grafana_provisioning_notification_policies_resetPolicies: []  # noqa var-naming
 
 # A list of provisioning mute timings to apply and delete.
 # See `../templates/provisioning/mute_timings.yaml.j2`
-grafana_provisioning_mute_timings: []
-grafana_provisioning_delete_mute_timings: []
+grafana_provisioning_mute_timings_muteTimes: []  # noqa var-naming
+grafana_provisioning_mute_timings_deleteMuteTimes: []  # noqa var-naming
 
 # A list of provisioning notification template groups to apply and delete.
 # See `../templates/provisioning/notification_template_groups.yaml.j2`
-grafana_provisioning_notification_template_groups: []
-grafana_provisioning_delete_notification_template_groups: []
+grafana_provisioning_notification_template_groups_templates: []  # noqa var-naming
+grafana_provisioning_notification_template_groups_deleteTemplates: []  # noqa var-naming
 
 # A list of provisioning plugins.
 # See `../templates/provisioning/plugins.yaml.j2`
-grafana_provisioning_plugins: []
+grafana_provisioning_plugins_apps: []  # noqa var-naming
 
 grafana_container_image: "{{ grafana_container_image_registry_prefix }}grafana/grafana-oss:{{ grafana_version }}"
 grafana_container_image_registry_prefix: "{{ grafana_container_image_registry_prefix_upstream }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,29 +110,35 @@ grafana_provisioning_dashboard_providers:
     options:
       path: /etc/grafana/dashboards
 
-# A list of provisioning datasources.
+# A list of provisioning datasources to apply and delete.
 # See `../templates/provisioning/datasources.yaml.j2`
 grafana_provisioning_datasources: []
+grafana_provisioning_delete_datasources: []
 
-# A list of provisioning alerts.
+# A list of provisioning alerts to apply and delete.
 # See `../templates/provisioning/alerts.yaml.j2`
 grafana_provisioning_alerts: []
+grafana_provisioning_delete_alerts: []
 
-# A list of provisioning contact points.
+# A list of provisioning contact points to apply and delete.
 # See `../templates/provisioning/contact_points.yaml.j2`
 grafana_provisioning_contact_points: []
+grafana_provisioning_delete_contact_points: []
 
-# A list of provisioning notification policies.
+# A list of provisioning notification policies to apply and reset.
 # See `../templates/provisioning/notification_policies.yaml.j2`
 grafana_provisioning_notification_policies: []
+grafana_provisioning_reset_notification_policies: []
 
-# A list of provisioning mute timings.
+# A list of provisioning mute timings to apply and delete.
 # See `../templates/provisioning/mute_timings.yaml.j2`
 grafana_provisioning_mute_timings: []
+grafana_provisioning_delete_mute_timings: []
 
-# A list of provisioning notification template groups.
+# A list of provisioning notification template groups to apply and delete.
 # See `../templates/provisioning/notification_template_groups.yaml.j2`
 grafana_provisioning_notification_template_groups: []
+grafana_provisioning_delete_notification_template_groups: []
 
 # A list of provisioning plugins.
 # See `../templates/provisioning/plugins.yaml.j2`

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,8 @@
     - "{{ grafana_config_path }}/provisioning"
     - "{{ grafana_config_path }}/provisioning/datasources"
     - "{{ grafana_config_path }}/provisioning/dashboards"
+    - "{{ grafana_config_path }}/provisioning/alerting"
+    - "{{ grafana_config_path }}/provisioning/plugins"
     - "{{ grafana_config_path }}/dashboards"
     - "{{ grafana_data_path }}"
 
@@ -30,6 +32,18 @@
       dst: "{{ grafana_config_path }}/provisioning/datasources/default.yaml"
     - src: provisioning/dashboards.yaml.j2
       dst: "{{ grafana_config_path }}/provisioning/dashboards/default.yaml"
+    - src: provisioning/alerts.yaml.j2
+      dst: "{{ grafana_config_path }}/provisioning/alerting/alerts.yaml"
+    - src: provisioning/contact_points.yaml.j2
+      dst: "{{ grafana_config_path }}/provisioning/alerting/contact_points.yaml"
+    - src: provisioning/mute_timings.yaml.j2
+      dst: "{{ grafana_config_path }}/provisioning/alerting/mute_timings.yaml"
+    - src: provisioning/notification_policies.yaml.j2
+      dst: "{{ grafana_config_path }}/provisioning/alerting/notification_policies.yaml"
+    - src: provisioning/notification_template_groups.yaml.j2
+      dst: "{{ grafana_config_path }}/provisioning/alerting/notification_template_groups.yaml"
+    - src: provisioning/plugins.yaml.j2
+      dst: "{{ grafana_config_path }}/provisioning/plugins/default.yaml"
     - src: labels.j2
       dst: "{{ grafana_base_path }}/labels"
     - src: env.j2

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -8,6 +8,8 @@
   when: "item.old in vars"
   with_items:
     - {'old': 'grafana_container_additional_networks_additional', 'new': 'grafana_container_additional_networks_custom'}
+    - {'old': 'grafana_provisioning_datasources', 'new': 'grafana_provisioning_datasources_datasources'}
+    - {'old': 'grafana_provisioning_dashboard_providers', 'new': 'grafana_provisioning_dashboards_providers'}
 
 - name: Fail if required Grafana settings not defined
   ansible.builtin.fail:

--- a/templates/provisioning/alerts.yaml.j2
+++ b/templates/provisioning/alerts.yaml.j2
@@ -1,5 +1,5 @@
 apiVersion: 1
 
-groups: {{ grafana_provisioning_alerts | to_json }}
+groups: {{ grafana_provisioning_alerts_groups | to_json }}
 
-deleteRules: {{ grafana_provisioning_delete_alerts | to_json }}
+deleteRules: {{ grafana_provisioning_alerts_deleteRules | to_json }}

--- a/templates/provisioning/alerts.yaml.j2
+++ b/templates/provisioning/alerts.yaml.j2
@@ -1,3 +1,5 @@
 apiVersion: 1
 
 groups: {{ grafana_provisioning_alerts | to_json }}
+
+deleteRules: {{ grafana_provisioning_delete_alerts | to_json }}

--- a/templates/provisioning/alerts.yaml.j2
+++ b/templates/provisioning/alerts.yaml.j2
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+groups: {{ grafana_provisioning_alerts | to_json }}

--- a/templates/provisioning/contact_points.yaml.j2
+++ b/templates/provisioning/contact_points.yaml.j2
@@ -1,5 +1,5 @@
 apiVersion: 1
 
-contactPoints: {{ grafana_provisioning_contact_points | to_json }}
+contactPoints: {{ grafana_provisioning_contact_points_contactPoints | to_json }}
 
-deleteContactPoints:: {{ grafana_provisioning_delete_contact_points | to_json }}
+deleteContactPoints:: {{ grafana_provisioning_contact_points_deleteContactPoints | to_json }}

--- a/templates/provisioning/contact_points.yaml.j2
+++ b/templates/provisioning/contact_points.yaml.j2
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+contactPoints: {{ grafana_provisioning_contact_points | to_json }}

--- a/templates/provisioning/contact_points.yaml.j2
+++ b/templates/provisioning/contact_points.yaml.j2
@@ -1,3 +1,5 @@
 apiVersion: 1
 
 contactPoints: {{ grafana_provisioning_contact_points | to_json }}
+
+deleteContactPoints:: {{ grafana_provisioning_delete_contact_points | to_json }}

--- a/templates/provisioning/dashboards.yaml.j2
+++ b/templates/provisioning/dashboards.yaml.j2
@@ -1,3 +1,3 @@
 apiVersion: 1
 
-providers: {{ grafana_provisioning_dashboard_providers | to_json }}
+providers: {{ grafana_provisioning_dashboards_providers | to_json }}

--- a/templates/provisioning/datasources.yaml.j2
+++ b/templates/provisioning/datasources.yaml.j2
@@ -1,3 +1,5 @@
 apiVersion: 1
 
 datasources: {{ grafana_provisioning_datasources | to_json }}
+
+deleteDatasources: {{ grafana_provisioning_delete_datasources | to_json }}

--- a/templates/provisioning/datasources.yaml.j2
+++ b/templates/provisioning/datasources.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: 1
 
-prune: {{ grafana_provisioning_prune_datasources | to_json }}
+prune: {{ grafana_provisioning_datasources_prune | to_json }}
 
-datasources: {{ grafana_provisioning_datasources | to_json }}
+datasources: {{ grafana_provisioning_datasources_datasources | to_json }}
 
-deleteDatasources: {{ grafana_provisioning_delete_datasources | to_json }}
+deleteDatasources: {{ grafana_provisioning_datasources_deleteDatasources | to_json }}

--- a/templates/provisioning/datasources.yaml.j2
+++ b/templates/provisioning/datasources.yaml.j2
@@ -1,5 +1,7 @@
 apiVersion: 1
 
+prune: {{ grafana_provisioning_prune_datasources }}
+
 datasources: {{ grafana_provisioning_datasources | to_json }}
 
 deleteDatasources: {{ grafana_provisioning_delete_datasources | to_json }}

--- a/templates/provisioning/datasources.yaml.j2
+++ b/templates/provisioning/datasources.yaml.j2
@@ -1,6 +1,6 @@
 apiVersion: 1
 
-prune: {{ grafana_provisioning_prune_datasources }}
+prune: {{ grafana_provisioning_prune_datasources | to_json }}
 
 datasources: {{ grafana_provisioning_datasources | to_json }}
 

--- a/templates/provisioning/mute_timings.yaml.j2
+++ b/templates/provisioning/mute_timings.yaml.j2
@@ -1,3 +1,5 @@
 apiVersion: 1
 
 muteTimes: {{ grafana_provisioning_mute_timings | to_json }}
+
+deleteMuteTimes: {{ grafana_provisioning_delete_mute_timings | to_json }}

--- a/templates/provisioning/mute_timings.yaml.j2
+++ b/templates/provisioning/mute_timings.yaml.j2
@@ -1,5 +1,5 @@
 apiVersion: 1
 
-muteTimes: {{ grafana_provisioning_mute_timings | to_json }}
+muteTimes: {{ grafana_provisioning_mute_timings_muteTimes | to_json }}
 
-deleteMuteTimes: {{ grafana_provisioning_delete_mute_timings | to_json }}
+deleteMuteTimes: {{ grafana_provisioning_mute_timings_deleteMuteTimes | to_json }}

--- a/templates/provisioning/mute_timings.yaml.j2
+++ b/templates/provisioning/mute_timings.yaml.j2
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+muteTimes: {{ grafana_provisioning_mute_timings | to_json }}

--- a/templates/provisioning/notification_policies.yaml.j2
+++ b/templates/provisioning/notification_policies.yaml.j2
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+policies: {{ grafana_provisioning_notification_policies | to_json }}

--- a/templates/provisioning/notification_policies.yaml.j2
+++ b/templates/provisioning/notification_policies.yaml.j2
@@ -1,5 +1,5 @@
 apiVersion: 1
 
-policies: {{ grafana_provisioning_notification_policies | to_json }}
+policies: {{ grafana_provisioning_notification_policies_policies | to_json }}
 
-resetPolicies: {{ grafana_provisioning_reset_notification_policies | to_json }}
+resetPolicies: {{ grafana_provisioning_notification_policies_resetPolicies | to_json }}

--- a/templates/provisioning/notification_policies.yaml.j2
+++ b/templates/provisioning/notification_policies.yaml.j2
@@ -1,3 +1,5 @@
 apiVersion: 1
 
 policies: {{ grafana_provisioning_notification_policies | to_json }}
+
+resetPolicies: {{ grafana_provisioning_reset_notification_policies | to_json }}

--- a/templates/provisioning/notification_template_groups.yaml.j2
+++ b/templates/provisioning/notification_template_groups.yaml.j2
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+templates: {{ grafana_provisioning_notification_template_groups | to_json }}

--- a/templates/provisioning/notification_template_groups.yaml.j2
+++ b/templates/provisioning/notification_template_groups.yaml.j2
@@ -1,5 +1,5 @@
 apiVersion: 1
 
-templates: {{ grafana_provisioning_notification_template_groups | to_json }}
+templates: {{ grafana_provisioning_notification_template_groups_templates | to_json }}
 
-deleteTemplates: {{ grafana_provisioning_delete_notification_template_groups | to_json }}
+deleteTemplates: {{ grafana_provisioning_notification_template_groups_deleteTemplates | to_json }}

--- a/templates/provisioning/notification_template_groups.yaml.j2
+++ b/templates/provisioning/notification_template_groups.yaml.j2
@@ -1,3 +1,5 @@
 apiVersion: 1
 
 templates: {{ grafana_provisioning_notification_template_groups | to_json }}
+
+deleteTemplates: {{ grafana_provisioning_delete_notification_template_groups | to_json }}

--- a/templates/provisioning/plugins.yaml.j2
+++ b/templates/provisioning/plugins.yaml.j2
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+apps: {{ grafana_provisioning_plugins | to_json }}

--- a/templates/provisioning/plugins.yaml.j2
+++ b/templates/provisioning/plugins.yaml.j2
@@ -1,3 +1,3 @@
 apiVersion: 1
 
-apps: {{ grafana_provisioning_plugins | to_json }}
+apps: {{ grafana_provisioning_plugins_apps | to_json }}


### PR DESCRIPTION
This ready.

Adds:
1. Flag to enable/disable automatic datasource pruning
2. List to support deleting datasources (if prune is disabled?)
3. provision alerts (create and delete)
4. provision contact points (create and delete)
5. provision notification policies (create and reset)
6. provision mute timings (create and delete)
7. provision notification templates (create and delete)
8. provision plugins

relevant docs:

1. https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/
2. https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources
3. https://grafana.com/docs/grafana/latest/administration/provisioning/#plugins

Additional notes: Unfortunately only data-sources support automatic pruning (https://github.com/grafana/grafana/issues/67036). Thus all of the delete variables. 

