### PR TITLE
Add support for host network

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,11 @@ grafana_container_image_force_pull: "{{ grafana_container_image.endswith(':lates
 grafana_container_http_host_bind_port: ''
 
 # The base container network. It will be auto-created by this role if it doesn't exist already.
+# You can specify 'host' network for container to use it.
+# In this case you will probably be interested to set GF_SERVER_HTTP_ADDR environment variable to not expose Grafana to the world.
+# grafana_environment_variables_additional_variables: |
+#   GF_SERVER_HTTP_ADDR=127.0.0.1
+# Setting variable to 'host' will silently ignore grafana_container_http_port and grafana_container_additional_networks variables.
 grafana_container_network: "{{ grafana_identifier }}"
 
 # The port number in the container

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -94,6 +94,7 @@
     name: "{{ grafana_container_network }}"
     driver: bridge
     driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
+  when: grafana_container_network != 'host'
 
 - name: Ensure Grafana systemd service installed
   ansible.builtin.template:

--- a/templates/systemd/grafana.service.j2
+++ b/templates/systemd/grafana.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--cap-drop=ALL \
 			--read-only \
 			--network={{ grafana_container_network }} \
-			{% if grafana_container_http_host_bind_port %}
+			{% if grafana_container_http_host_bind_port and grafana_container_network != 'host' %}
 			-p {{ grafana_container_http_host_bind_port }}:{{ grafana_container_http_port }} \
 			{% endif %}
 			--env-file={{ grafana_base_path }}/env \
@@ -42,9 +42,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ grafana_container_image }}
 
+{% if grafana_container_network != 'host' %}
 {% for network in grafana_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ grafana_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ grafana_identifier }}
 


### PR DESCRIPTION
Some users would have datasources running on the host machine. To let them discover it container should have an option to be created using `host` network. 

Currently playbook would try to create network specified in `grafana_container_network` variable causing it to fail:

```plain
TASK [ansible-role-grafana : Ensure Grafana container network is created] **********************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.community.docker.plugins.module_utils._api.errors.APIError: 403 Client Error for http+docker://localhost/v1.48/networks/host: Forbidden ("host is a pre-defined network and cannot be removed")
fatal: [ru-1]: FAILED! => {"changed": false, "msg": "An unexpected Docker error occurred: 403 Client Error for http+docker://localhost/v1.48/networks/host: Forbidden (\"host is a pre-defined network and cannot be removed\")"}
```

This PR lets user specify `host` network for container to connect. 