### PR TITLE
feat: add support for Grafana alerting templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -219,9 +219,17 @@ grafana_smtp_from_address: ""
 #
 # Example:
 # grafana_provisioning_dashboard_template_files:
-#   - name: /path/to/my-dashboard.json
+#   - path: /path/to/my-dashboard.json.j2
 #     name: my-dashboard.json
 grafana_provisioning_dashboard_template_files: []
+
+# A list of template files on the Ansible controller server to install into the alerting directory.
+#
+# Example:
+# grafana_provisioning_alerting_template_files:
+#   - path: /path/to/my-alert.yml.j2
+#     name: my-alert.yml
+grafana_provisioning_alerting_template_files: []
 
 # A list of provisioning dashboard providers.
 # See `../templates/provisioning/dashboards.yaml.j2`

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -76,6 +76,15 @@
     group: "{{ grafana_gid }}"
   with_items: "{{ grafana_provisioning_dashboard_template_files }}"
 
+- name: Ensure Grafana alerting templates installed
+  ansible.builtin.template:
+    src: "{{ item.path }}"
+    dest: "{{ grafana_config_path }}/provisioning/alerting/{{ item.name }}"
+    mode: "0440"
+    owner: "{{ grafana_uid }}"
+    group: "{{ grafana_gid }}"
+  with_items: "{{ grafana_provisioning_alerting_template_files }}"
+
 - name: Ensure Grafana container image is pulled via community.docker.docker_image
   when: devture_systemd_docker_base_container_image_pull_method == 'ansible-module'
   community.docker.docker_image:


### PR DESCRIPTION
This PR adds the ability to provision Grafana alerting rules from local template files, similar to the existing functionality for dashboards.

